### PR TITLE
Clean-up queue code a bit

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,33 +1,16 @@
 import { Logger } from '@l2beat/backend-tools'
-import { Token } from '@prisma/client'
 import { createPrismaClient } from './db/prisma.js'
 import { connection } from './redis/redis.js'
-import { buildCoingeckoSource } from './sources/coingecko.js'
-import { buildDeploymentSource } from './sources/deployment.js'
-import { buildOrbitSource } from './sources/orbit.js'
-import { buildTokenListSource } from './sources/tokenList.js'
-import { buildWormholeSource } from './sources/wormhole.js'
-import { getNetworksConfig, withExplorer } from './utils/getNetworksConfig.js'
+import { getNetworksConfig } from './utils/getNetworksConfig.js'
 import { eventRouter } from './utils/queue/router/index.js'
 import { setupQueue } from './utils/queue/setup-queue.js'
-import { setupQueueWithProcessor } from './utils/queue/queue-with-processor.js'
-import {
-  wrapDeploymentUpdatedQueue,
-  wrapTokenQueue,
-} from './utils/queue/wrap.js'
-import { setupCollector } from './utils/queue/aggregates/collector.js'
-import { buildArbitrumCanonicalSource } from './sources/arbitrumCanonical.js'
-import { buildOptimismCanonicalSource } from './sources/optimismCanonical.js'
-import { buildAxelarConfigSource } from './sources/axelarConfig.js'
-import { buildAxelarGatewaySource } from './sources/axelarGateway.js'
-import { buildOnChainMetadataSource } from './sources/onChainMetadata.js'
 import { byTokenChainId } from './utils/queue/router/routing-key-rules.js'
 import { env } from './env.js'
 import { startQueueDashboard } from './utils/queue/dashboard.js'
-import { buildZkSyncCanonicalSource } from './sources/zkSyncCanonical.js'
-
-type TokenPayload = { tokenId: Token['id'] }
-type BatchTokenPayload = { tokenIds: Token['id'][] }
+import { setupIndependentQueues } from './queues/independent.js'
+import { setupCanonicalQueues } from './queues/canonical.js'
+import { setupDeploymentQueues } from './queues/deployment.js'
+import { setupOnChainMetadataQueues } from './queues/onChain.js'
 
 const db = createPrismaClient()
 
@@ -43,330 +26,68 @@ const router = eventRouter({
   logger,
 })
 
-const queueWithProcessor = setupQueueWithProcessor({ connection, logger })
 const queue = setupQueue({ connection })
 
-const lists = [
-  {
-    tag: '1INCH',
-    url: 'https://tokens.1inch.eth.link',
-  },
-  {
-    tag: 'AAVE',
-    url: 'http://tokenlist.aave.eth.link',
-  },
-  {
-    tag: 'MYCRYPTO',
-    url: 'https://uniswap.mycryptoapi.com/',
-  },
-  {
-    tag: 'SUPERCHAIN',
-    url: 'https://static.optimism.io/optimism.tokenlist.json',
-  },
-]
-
-// #region Deployment processors
-// Routing inbox where TokenUpdate events are broadcasted from independent sources
-const deploymentRoutingInbox = queue<TokenPayload>({
-  name: 'DeploymentRoutingInbox',
-})
-
-// Output queue for the deployment processors where the tokenIds are broadcasted if the deployment is updated
-const deploymentUpdatedInbox = queue<TokenPayload>({
-  name: 'DeploymentUpdatedInbox',
-})
-
-const deploymentUpdatedQueue = wrapDeploymentUpdatedQueue(
-  deploymentUpdatedInbox,
-)
-
-// For each supported network with an explorer, create a deployment processor
-const deploymentProcessors = networksConfig
-  .filter(withExplorer)
-  .map((networkConfig) => {
-    const processor = buildDeploymentSource({
-      logger,
-      db,
-      networkConfig,
-      queue: deploymentUpdatedQueue,
-    })
-
-    const bus = queueWithProcessor<TokenPayload>({
-      name: `DeploymentProcessor:${networkConfig.name}`,
-      processor: (job) => {
-        return processor(job.data.tokenId)
-      },
-    })
-
-    return {
-      queue: bus.queue,
-      routingKey: networkConfig.chainId,
-    }
-  })
-
-// Route the events from deploymentRoutingInbox to the per-chain deployment processors
-router.routingKey({
-  from: deploymentRoutingInbox,
-  to: deploymentProcessors,
-  extractRoutingKey: byTokenChainId({ db }),
-})
-// #endregion Deployment processors
-
-// #region Canonical sources - Arbitrum
-const arbitrumCanonicalProcessor = queueWithProcessor<BatchTokenPayload>({
-  name: 'ArbitrumCanonicalProcessor',
-  processor: buildArbitrumCanonicalSource({ logger, db, networksConfig }),
-})
-
-// Handle backpressure from the deployment processor
-const arbitrumCanonicalEventCollector = queue<TokenPayload>({
-  name: 'ArbitrumCanonicalEventCollector',
-})
-const oneMinuteMs = 60 * 1000
-
-setupCollector({
-  inputQueue: arbitrumCanonicalEventCollector,
-  outputQueue: arbitrumCanonicalProcessor.queue,
-  aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
-  bufferSize: 100,
-  flushIntervalMs: oneMinuteMs,
-  connection,
+const deps = {
+  db,
   logger,
-})
-// #endregion Canonical sources - Arbitrum
-
-// #region Canonical sources - Optimism
-const optimismCanonicalProcessor = queueWithProcessor<BatchTokenPayload>({
-  name: 'OptimismCanonicalProcessor',
-  processor: buildOptimismCanonicalSource({ logger, db, networksConfig }),
-})
-
-// Handle backpressure from the deployment processor
-const optimismCanonicalEventCollector = queue<TokenPayload>({
-  name: 'OptimismCanonicalEventCollector',
-})
-
-setupCollector({
-  inputQueue: optimismCanonicalEventCollector,
-  outputQueue: optimismCanonicalProcessor.queue,
-  aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
-  bufferSize: 100,
-  flushIntervalMs: oneMinuteMs,
   connection,
-  logger,
-})
-// #endregion Canonical sources - Optimism
+  networksConfig,
+}
 
-// #region Canonical sources - ZkSync
-const zkSyncCanonicalProcessor = queueWithProcessor<BatchTokenPayload>({
-  name: 'ZkSyncCanonicalProcessor',
-  processor: buildZkSyncCanonicalSource({ logger, db, networksConfig }),
-})
+const canonical = await setupCanonicalQueues(deps)
+const deployment = await setupDeploymentQueues(deps)
+const independent = await setupIndependentQueues(deps)
+const onChainMetadata = await setupOnChainMetadataQueues(deps)
 
-// Handle backpressure from the deployment processor
-const zkSyncCanonicalEventCollector = queue<TokenPayload>({
-  name: 'ZkSyncCanonicalEventCollector',
-})
-
-setupCollector({
-  inputQueue: zkSyncCanonicalEventCollector,
-  outputQueue: zkSyncCanonicalProcessor.queue,
-  aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
-  bufferSize: 100,
-  flushIntervalMs: oneMinuteMs,
-  connection,
-  logger,
-})
-// #endregion Canonical sources - ZkSync
-
-// #region Canonical sources update wire up
-router.routingKey({
-  from: deploymentUpdatedInbox,
+// When token deployment is updated, route the event to the canonical processors since these are dependent on the deployment data
+const deploymentToCanonicalRoutingWorker = router.routingKey({
+  from: deployment.update.inbox,
   to: [
     // Ditch the rest
     {
-      queue: arbitrumCanonicalEventCollector,
+      queue: canonical.arbitrum.collector.queue,
       routingKey: 42161,
     },
     {
-      queue: optimismCanonicalEventCollector,
+      queue: canonical.optimism.collector.queue,
       routingKey: 10,
     },
     {
-      queue: zkSyncCanonicalEventCollector,
+      queue: canonical.zkSync.collector.queue,
       routingKey: 324,
+    },
+    // Also notify about new canonical token deployments
+    {
+      queue: [
+        canonical.arbitrum.collector.queue,
+        canonical.optimism.collector.queue,
+        canonical.zkSync.collector.queue,
+      ],
+      routingKey: 1,
     },
   ],
   extractRoutingKey: byTokenChainId({ db }),
 })
-// #endregion Canonical sources update wire up
-
-const tokenUpdateInbox = queue<TokenPayload>({
-  name: 'TokenUpdateInbox',
-})
-
-const tokenUpdateQueue = wrapTokenQueue(tokenUpdateInbox)
-
-// #region On-chain metadata sources
-// Routing inbox where TokenUpdate events are broadcasted from independent sources
-const onChainMetadataRoutingInbox = queue<TokenPayload>({
-  name: 'OnChainMetadataRoutingInbox',
-})
-
-// For each network, create routing inbox and backpressure (collector) queue
-// so we can batch process the events instead of calling node for each token
-const onChainMetadataBuses = networksConfig
-  .filter(withExplorer)
-  .map((networkConfig) => {
-    // Per-chain events will be collected here
-    const eventCollectorInbox = queue<TokenPayload>({
-      name: `OnChainMetadataEventCollector:${networkConfig.name}`,
-    })
-
-    // Batch processor for the collected events
-    const batchEventProcessor = queueWithProcessor<BatchTokenPayload>({
-      name: `OnChainMetadataBatchProcessor:${networkConfig.name}`,
-      processor: (job) =>
-        buildOnChainMetadataSource({
-          logger,
-          db,
-          networkConfig,
-        })(job.data.tokenIds),
-    })
-
-    // Wire up the collector to the processor
-    setupCollector({
-      inputQueue: eventCollectorInbox,
-      outputQueue: batchEventProcessor.queue,
-      aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
-      bufferSize: 100,
-      flushIntervalMs: oneMinuteMs,
-      connection,
-      logger,
-    })
-
-    return {
-      queue: eventCollectorInbox,
-      batchQueue: batchEventProcessor.queue,
-      routingKey: networkConfig.chainId,
-    }
-  })
-
-// Route the events from the global inbox to the per-chain event collectors
-router.routingKey({
-  from: onChainMetadataRoutingInbox,
-  to: onChainMetadataBuses.map((bus) => ({
-    queue: bus.queue,
-    routingKey: bus.routingKey,
-  })),
-  extractRoutingKey: byTokenChainId({ db }),
-})
-// #endregion On-chain metadata sources
-// #region Independent sources
-
-const coingeckoSource = buildCoingeckoSource({
-  logger,
-  db,
-  queue: tokenUpdateQueue,
-})
-const axelarConfigSource = buildAxelarConfigSource({
-  logger,
-  db,
-  queue: tokenUpdateQueue,
-})
-const wormholeSource = buildWormholeSource({
-  logger,
-  db,
-  queue: tokenUpdateQueue,
-})
-const orbitSource = buildOrbitSource({ logger, db, queue: tokenUpdateQueue })
-const tokenListSources = lists.map(({ tag, url }) =>
-  queueWithProcessor({
-    name: `TokenListProcessor:${tag}`,
-    processor: buildTokenListSource({
-      tag,
-      url,
-      logger,
-      db,
-      queue: tokenUpdateQueue,
-    }),
-  }),
-)
-
-// const lzV1Sources = networksConfig.filter(withExplorer).map((networkConfig) => {
-//   return {
-//     name: `LayerZeroV1Processor:${networkConfig.name}`,
-//     processor: buildLayerZeroV1Source({
-//       logger,
-//       db,
-//       networkConfig,
-//       queue: tokenUpdateQueue,
-//     }),
-//   }
-// })
-
-// const lzV1Queues = lzV1Sources.map((source) => sourceQueue(source))
-
-const axelarGatewayQueues = networksConfig.map((networkConfig) =>
-  queueWithProcessor({
-    name: `AxelarGatewayProcessor:${networkConfig.name}`,
-    processor: buildAxelarGatewaySource({
-      logger,
-      db,
-      networkConfig,
-      queue: tokenUpdateQueue,
-    }),
-  }),
-)
-
-const coingeckoQueue = queueWithProcessor({
-  name: 'CoingeckoProcessor',
-  processor: coingeckoSource,
-})
-
-const axelarConfigQueue = queueWithProcessor({
-  name: 'AxelarConfigProcessor',
-  processor: axelarConfigSource,
-})
-
-const wormholeQueue = queueWithProcessor({
-  name: 'WormholeProcessor',
-  processor: wormholeSource,
-})
-
-const orbitQueue = queueWithProcessor({
-  name: 'OrbitProcessor',
-  processor: orbitSource,
-})
-
-const independentSources = [
-  coingeckoQueue,
-  ...axelarGatewayQueues,
-  axelarConfigQueue,
-  wormholeQueue,
-  orbitQueue,
-  ...tokenListSources,
-  // ...lzV1Queues,
-]
 
 // Input signal, might be removed
 const refreshInbox = queue({
   name: 'RefreshInbox',
 })
 
+const independentSources = Object.values(independent.sources).flat()
+
 // Input signal, might be removed
-router.broadcast({
+const refreshBroadcastWorker = router.broadcast({
   from: refreshInbox,
   to: independentSources.map((q) => q.queue),
 })
 
-// Broadcast the token update events to the independent sources to dependant sources
-router.broadcast({
-  from: tokenUpdateInbox,
-  to: [deploymentRoutingInbox, onChainMetadataRoutingInbox],
+// Broadcast the token update events to the dependent sources to dependant sources
+const independentBroadcastWorker = router.broadcast({
+  from: independent.inbox,
+  to: [deployment.routing.inbox, onChainMetadata.routing.inbox],
 })
-
-// #endregion Independent sources
 
 // #region BullBoard
 
@@ -374,19 +95,29 @@ const dashboardLogger = logger.for('QueueDashboard')
 
 if (env.QUEUE_DASHBOARD_PORT) {
   const allQueues = [
-    deploymentRoutingInbox,
-    tokenUpdateInbox,
     refreshInbox,
+
+    // Independent
+    independent.inbox,
     independentSources.map((q) => q.queue),
-    deploymentProcessors.map((p) => p.queue),
-    arbitrumCanonicalEventCollector,
-    optimismCanonicalEventCollector,
-    arbitrumCanonicalProcessor.queue,
-    optimismCanonicalProcessor.queue,
-    deploymentUpdatedInbox,
-    onChainMetadataBuses.map((b) => b.queue),
-    onChainMetadataBuses.map((b) => b.batchQueue),
-    onChainMetadataRoutingInbox,
+
+    // Deployment
+    deployment.routing.inbox,
+    deployment.update.inbox,
+    deployment.buses.map((b) => b.queue),
+
+    // Canonical
+    canonical.arbitrum.collector.queue,
+    canonical.arbitrum.processor.queue,
+    canonical.optimism.collector.queue,
+    canonical.optimism.processor.queue,
+    canonical.zkSync.collector.queue,
+    canonical.zkSync.processor.queue,
+
+    // Onchain
+    onChainMetadata.routing.inbox,
+    onChainMetadata.buses.map((b) => b.collector.queue),
+    onChainMetadata.buses.map((b) => b.processor.queue),
   ].flat()
 
   await startQueueDashboard({
@@ -399,3 +130,15 @@ if (env.QUEUE_DASHBOARD_PORT) {
   dashboardLogger.warn('Queue dashboard is disabled')
 }
 // #endregion BullBoard
+
+// Start all the workers
+await Promise.all([
+  refreshBroadcastWorker.run(),
+  independentBroadcastWorker.run(),
+  deploymentToCanonicalRoutingWorker.run(),
+
+  independent.start(),
+  canonical.start(),
+  deployment.start(),
+  onChainMetadata.start(),
+])

--- a/src/queues/canonical.ts
+++ b/src/queues/canonical.ts
@@ -8,11 +8,9 @@ import { buildArbitrumCanonicalSource } from '../sources/arbitrumCanonical.js'
 import { setupCollector } from '../utils/queue/aggregates/collector.js'
 import { buildOptimismCanonicalSource } from '../sources/optimismCanonical.js'
 import { buildZkSyncCanonicalSource } from '../sources/zkSyncCanonical.js'
+import { BatchTokenPayload, TokenPayload } from './payloads.js'
 
 const oneMinuteMs = 60 * 1000
-
-type TokenPayload = { tokenId: string }
-type BatchTokenPayload = { tokenIds: string[] }
 
 export async function setupCanonicalQueues({
   connection,

--- a/src/queues/canonical.ts
+++ b/src/queues/canonical.ts
@@ -1,0 +1,136 @@
+import { Redis } from 'ioredis'
+import { PrismaClient } from '../db/prisma.js'
+import { Logger } from '@l2beat/backend-tools'
+import { NetworkConfig } from '../utils/getNetworksConfig.js'
+import { setupQueue } from '../utils/queue/setup-queue.js'
+import { setupQueueWithProcessor } from '../utils/queue/queue-with-processor.js'
+import { buildArbitrumCanonicalSource } from '../sources/arbitrumCanonical.js'
+import { setupCollector } from '../utils/queue/aggregates/collector.js'
+import { buildOptimismCanonicalSource } from '../sources/optimismCanonical.js'
+import { buildZkSyncCanonicalSource } from '../sources/zkSyncCanonical.js'
+
+const oneMinuteMs = 60 * 1000
+
+type TokenPayload = { tokenId: string }
+type BatchTokenPayload = { tokenIds: string[] }
+
+export async function setupCanonicalQueues({
+  connection,
+  db,
+  logger,
+  networksConfig,
+}: {
+  connection: Redis
+  db: PrismaClient
+  logger: Logger
+  networksConfig: NetworkConfig[]
+}) {
+  const deps = {
+    connection,
+    logger,
+  }
+
+  const queue = setupQueue(deps)
+  const queueWithProcessor = setupQueueWithProcessor(deps)
+
+  // Arbitrum
+  const arbitrumCanonicalProcessor = queueWithProcessor<BatchTokenPayload>({
+    name: 'ArbitrumCanonicalBatchProcessor',
+    processor: buildArbitrumCanonicalSource({ logger, db, networksConfig }),
+  })
+  const arbitrumCanonicalEventCollector = queue<TokenPayload>({
+    name: 'ArbitrumCanonicalEventCollector',
+  })
+
+  // Handle backpressure from the deployment processor (for each below)
+  const arbitrumCollectorWorker = setupCollector({
+    inputQueue: arbitrumCanonicalEventCollector,
+    outputQueue: arbitrumCanonicalProcessor.queue,
+    aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
+    bufferSize: 100,
+    flushIntervalMs: oneMinuteMs,
+    connection,
+    logger,
+  })
+
+  // Optimism
+  const optimismCanonicalProcessor = queueWithProcessor<BatchTokenPayload>({
+    name: 'OptimismCanonicalBatchProcessor',
+    processor: buildOptimismCanonicalSource({ logger, db, networksConfig }),
+  })
+  const optimismCanonicalEventCollector = queue<TokenPayload>({
+    name: 'OptimismCanonicalEventCollector',
+  })
+
+  const optimismCollectorWorker = setupCollector({
+    inputQueue: optimismCanonicalEventCollector,
+    outputQueue: optimismCanonicalProcessor.queue,
+    aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
+    bufferSize: 100,
+    flushIntervalMs: oneMinuteMs,
+    connection,
+    logger,
+  })
+
+  // ZkSync
+  const zkSyncCanonicalProcessor = queueWithProcessor<BatchTokenPayload>({
+    name: 'ZkSyncCanonicalBatchProcessor',
+    processor: buildZkSyncCanonicalSource({ logger, db, networksConfig }),
+  })
+  const zkSyncCanonicalEventCollector = queue<TokenPayload>({
+    name: 'ZkSyncCanonicalEventCollector',
+  })
+
+  const zkSyncCollectorWorker = setupCollector({
+    inputQueue: zkSyncCanonicalEventCollector,
+    outputQueue: zkSyncCanonicalProcessor.queue,
+    aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
+    bufferSize: 100,
+    flushIntervalMs: oneMinuteMs,
+    connection,
+    logger,
+  })
+
+  function start() {
+    const statusLogger = logger.for('CanonicalQueuesModule')
+    statusLogger.info('Starting')
+
+    const toRun = [
+      arbitrumCollectorWorker,
+      arbitrumCanonicalProcessor.worker,
+      optimismCollectorWorker,
+      optimismCanonicalProcessor.worker,
+      zkSyncCollectorWorker,
+      zkSyncCanonicalProcessor.worker,
+    ]
+
+    toRun.forEach((worker) => worker.run())
+
+    statusLogger.info('Started')
+  }
+
+  return {
+    start,
+    arbitrum: {
+      processor: arbitrumCanonicalProcessor,
+      collector: {
+        queue: arbitrumCanonicalEventCollector,
+        worker: arbitrumCollectorWorker,
+      },
+    },
+    optimism: {
+      processor: optimismCanonicalProcessor,
+      collector: {
+        queue: optimismCanonicalEventCollector,
+        worker: optimismCollectorWorker,
+      },
+    },
+    zkSync: {
+      processor: zkSyncCanonicalProcessor,
+      collector: {
+        queue: zkSyncCanonicalEventCollector,
+        worker: zkSyncCollectorWorker,
+      },
+    },
+  }
+}

--- a/src/queues/deployment.ts
+++ b/src/queues/deployment.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@l2beat/backend-tools'
+import { PrismaClient } from '../db/prisma.js'
+import { NetworkConfig, withExplorer } from '../utils/getNetworksConfig.js'
+import { Redis } from 'ioredis'
+import { eventRouter } from '../utils/queue/router/index.js'
+import { setupQueueWithProcessor } from '../utils/queue/queue-with-processor.js'
+import { TokenPayload } from './payloads.js'
+import { wrapDeploymentUpdatedQueue } from '../utils/queue/wrap.js'
+import { setupQueue } from '../utils/queue/setup-queue.js'
+import { buildDeploymentSource } from '../sources/deployment.js'
+import { byTokenChainId } from '../utils/queue/router/routing-key-rules.js'
+
+export async function setupDeploymentQueues({
+  connection,
+  db,
+  logger,
+  networksConfig,
+}: {
+  connection: Redis
+  db: PrismaClient
+  logger: Logger
+  networksConfig: NetworkConfig[]
+}) {
+  const deps = {
+    connection,
+    logger,
+  }
+
+  const router = eventRouter(deps)
+  const queue = setupQueue(deps)
+  const queueWithProcessor = setupQueueWithProcessor(deps)
+
+  // Routing inbox where TokenUpdate events are broadcasted from independent sources
+  const routingInbox = queue<TokenPayload>({ name: 'DeploymentRoutingInbox' })
+
+  // Output queue for the deployment processors where the tokenIds are broadcasted if the deployment is updated
+  const updatedInbox = queue<TokenPayload>({ name: 'DeploymentUpdatedInbox' })
+  const updatedQueue = wrapDeploymentUpdatedQueue(updatedInbox)
+
+  // For each supported network with an explorer, create a deployment processor
+  const buses = networksConfig.filter(withExplorer).map((networkConfig) => {
+    const processor = buildDeploymentSource({
+      logger,
+      db,
+      networkConfig,
+      queue: updatedQueue,
+    })
+    const { queue, worker } = queueWithProcessor<TokenPayload>({
+      name: `DeploymentProcessor:${networkConfig.name}`,
+      processor: (job) => processor(job.data.tokenId),
+    })
+
+    return { queue, worker, routingKey: networkConfig.chainId }
+  })
+
+  // Route the events from routing inbox to the per-chain deployment processors
+  const routeingWorker = router.routingKey({
+    from: routingInbox,
+    to: buses,
+    extractRoutingKey: byTokenChainId({ db }),
+  })
+
+  async function start() {
+    const statusLogger = logger.for('DeploymentQueuesModule')
+
+    buses.forEach(({ worker }) => worker.run())
+    routeingWorker.run()
+
+    statusLogger.info('Started')
+  }
+
+  return {
+    start,
+    routing: {
+      inbox: routingInbox,
+      worker: routeingWorker,
+    },
+    update: {
+      inbox: updatedInbox,
+    },
+    buses,
+  }
+}

--- a/src/queues/independent.ts
+++ b/src/queues/independent.ts
@@ -1,0 +1,118 @@
+import { Logger } from '@l2beat/backend-tools'
+import { Redis } from 'ioredis'
+import { PrismaClient } from '../db/prisma.js'
+import { setupQueue } from '../utils/queue/setup-queue.js'
+import { setupQueueWithProcessor } from '../utils/queue/queue-with-processor.js'
+import { TokenPayload } from './payloads.js'
+import { wrapTokenQueue } from '../utils/queue/wrap.js'
+import { buildCoingeckoSource } from '../sources/coingecko.js'
+import { buildAxelarConfigSource } from '../sources/axelarConfig.js'
+import { buildWormholeSource } from '../sources/wormhole.js'
+import { buildOrbitSource } from '../sources/orbit.js'
+import { buildTokenListSource } from '../sources/tokenList.js'
+import { NetworkConfig } from '../utils/getNetworksConfig.js'
+import { buildAxelarGatewaySource } from '../sources/axelarGateway.js'
+
+export async function setupIndependentQueues({
+  db,
+  logger,
+  connection,
+  networksConfig,
+}: {
+  db: PrismaClient
+  logger: Logger
+  connection: Redis
+  networksConfig: NetworkConfig[]
+}) {
+  const deps = {
+    connection,
+    logger,
+  }
+  const queue = setupQueue(deps)
+  const queueWithProcessor = setupQueueWithProcessor(deps)
+
+  const tokenUpdateInbox = queue<TokenPayload>({ name: 'TokenUpdateInbox' })
+  const tokenUpdateQueue = wrapTokenQueue(tokenUpdateInbox)
+
+  const lists = [
+    { tag: '1INCH', url: 'https://tokens.1inch.eth.link' },
+    { tag: 'AAVE', url: 'http://tokenlist.aave.eth.link' },
+    { tag: 'MYCRYPTO', url: 'https://uniswap.mycryptoapi.com/' },
+    {
+      tag: 'SUPERCHAIN',
+      url: 'https://static.optimism.io/optimism.tokenlist.json',
+    },
+  ]
+
+  const coingecko = queueWithProcessor({
+    name: 'CoingeckoProcessor',
+    processor: buildCoingeckoSource({ logger, db, queue: tokenUpdateQueue }),
+  })
+
+  const axelarConfig = queueWithProcessor({
+    name: 'AxelarConfigProcessor',
+    processor: buildAxelarConfigSource({ logger, db, queue: tokenUpdateQueue }),
+  })
+
+  const wormhole = queueWithProcessor({
+    name: 'WormholeProcessor',
+    processor: buildWormholeSource({ logger, db, queue: tokenUpdateQueue }),
+  })
+
+  const orbit = queueWithProcessor({
+    name: 'OrbitProcessor',
+    processor: buildOrbitSource({ logger, db, queue: tokenUpdateQueue }),
+  })
+
+  const tokenLists = lists.map(({ tag, url }) =>
+    queueWithProcessor({
+      name: `TokenListProcessor:${tag}`,
+      processor: buildTokenListSource({
+        tag,
+        url,
+        logger,
+        db,
+        queue: tokenUpdateQueue,
+      }),
+    }),
+  )
+
+  const axelarGateway = networksConfig.map((networkConfig) =>
+    queueWithProcessor({
+      name: `AxelarGatewayProcessor:${networkConfig.name}`,
+      processor: buildAxelarGatewaySource({
+        logger,
+        db,
+        networkConfig,
+        queue: tokenUpdateQueue,
+      }),
+    }),
+  )
+
+  async function start() {
+    const statusLogger = logger.for('IndependentQueuesModule')
+    statusLogger.info('Starting')
+
+    coingecko.worker.run()
+    axelarConfig.worker.run()
+    wormhole.worker.run()
+    orbit.worker.run()
+    tokenLists.forEach(({ worker }) => worker.run())
+    axelarGateway.forEach(({ worker }) => worker.run())
+
+    statusLogger.info('Started')
+  }
+
+  return {
+    start,
+    sources: {
+      coingecko,
+      axelarConfig,
+      wormhole,
+      orbit,
+      tokenLists,
+      axelarGateway,
+    },
+    inbox: tokenUpdateInbox,
+  }
+}

--- a/src/queues/onChain.ts
+++ b/src/queues/onChain.ts
@@ -1,0 +1,114 @@
+import { Redis } from 'ioredis'
+import { PrismaClient } from '../db/prisma.js'
+import { Logger } from '@l2beat/backend-tools'
+import { NetworkConfig, withExplorer } from '../utils/getNetworksConfig.js'
+import { eventRouter } from '../utils/queue/router/index.js'
+import { setupQueue } from '../utils/queue/setup-queue.js'
+import { setupQueueWithProcessor } from '../utils/queue/queue-with-processor.js'
+import { setupCollector } from '../utils/queue/aggregates/collector.js'
+import { buildOnChainMetadataSource } from '../sources/onChainMetadata.js'
+import { byTokenChainId } from '../utils/queue/router/routing-key-rules.js'
+
+const oneMinuteMs = 60 * 1000
+
+type TokenPayload = { tokenId: string }
+type BatchTokenPayload = { tokenIds: string[] }
+
+export async function setupOnChainMetadataQueues({
+  connection,
+  db,
+  logger,
+  networksConfig,
+}: {
+  connection: Redis
+  db: PrismaClient
+  logger: Logger
+  networksConfig: NetworkConfig[]
+}) {
+  const deps = {
+    connection,
+    logger,
+  }
+
+  const queue = setupQueue(deps)
+  const queueWithProcessor = setupQueueWithProcessor(deps)
+  const router = eventRouter(deps)
+
+  // Routing inbox where TokenUpdate events are broadcasted from independent sources
+  const onChainMetadataRoutingInbox = queue<TokenPayload>({
+    name: 'OnChainMetadataRoutingInbox',
+  })
+
+  // For each network, create routing inbox and backpressure (collector) queue
+  // so we can batch process the events instead of calling node for each token
+  const onChainMetadataBuses = networksConfig
+    .filter(withExplorer)
+    .map((networkConfig) => {
+      // Per-chain events will be collected here
+      const inbox = queue<TokenPayload>({
+        name: `OnChainMetadataEventCollector:${networkConfig.name}`,
+      })
+      // Batch processor for the collected events
+      const batchEventProcessor = queueWithProcessor<BatchTokenPayload>({
+        name: `OnChainMetadataBatchProcessor:${networkConfig.name}`,
+        processor: (job) =>
+          buildOnChainMetadataSource({ logger, db, networkConfig })(
+            job.data.tokenIds,
+          ),
+      })
+
+      // Wire up the collector to the processor
+      const worker = setupCollector({
+        inputQueue: inbox,
+        outputQueue: batchEventProcessor.queue,
+        aggregate: (data) => ({ tokenIds: data.map((d) => d.tokenId) }),
+        bufferSize: 100,
+        flushIntervalMs: oneMinuteMs,
+        connection,
+        logger,
+      })
+
+      return {
+        collector: {
+          queue: inbox,
+          worker,
+        },
+        processor: batchEventProcessor,
+        routingKey: networkConfig.chainId,
+      }
+    })
+
+  // Route the events from the inbox to the per-chain event collectors
+  const routingWorker = router.routingKey({
+    from: onChainMetadataRoutingInbox,
+    to: onChainMetadataBuses.map((bus) => ({
+      queue: bus.collector.queue,
+      routingKey: bus.routingKey,
+    })),
+    extractRoutingKey: byTokenChainId({ db }),
+  })
+
+  async function start() {
+    const statusLogger = logger.for('OnChainMetadataQueuesModule')
+    statusLogger.info('Starting')
+
+    const toRun = [
+      ...onChainMetadataBuses.map((bus) => bus.collector.worker),
+      ...onChainMetadataBuses.map((bus) => bus.processor.worker),
+      routingWorker,
+    ]
+
+    toRun.forEach((worker) => worker.run())
+
+    statusLogger.info('Started')
+  }
+
+  return {
+    start,
+    routing: {
+      inbox: onChainMetadataRoutingInbox,
+      worker: routingWorker,
+    },
+    buses: onChainMetadataBuses,
+  }
+}

--- a/src/queues/payloads.ts
+++ b/src/queues/payloads.ts
@@ -1,0 +1,4 @@
+import { Token } from '@prisma/client'
+
+export type TokenPayload = { tokenId: Token['id'] }
+export type BatchTokenPayload = { tokenIds: Token['id'][] }

--- a/src/utils/queue/aggregates/collector.ts
+++ b/src/utils/queue/aggregates/collector.ts
@@ -1,8 +1,9 @@
 import { Logger } from '@l2beat/backend-tools'
-import { Job, Queue, Worker } from 'bullmq'
+import { Job, Queue } from 'bullmq'
 import { Redis } from 'ioredis'
 import { setupWorkerLogging } from '../logging.js'
 import { InferQueueDataType, InferQueueResultType } from '../types.js'
+import { setupWorker } from '../setup-worker.js'
 
 type BufferEntry<T> = {
   payload: T
@@ -113,9 +114,12 @@ export function setupCollector<
     })
   }
 
-  const worker = new Worker<InputDataType>(inputQueue.name, processor, {
+  const worker = setupWorker({
+    queue: inputQueue,
     connection,
-    concurrency: bufferSize,
+    processor,
+    logger,
+    workerOptions: { concurrency: bufferSize },
   })
 
   if (logger) {

--- a/src/utils/queue/router/broadcast.ts
+++ b/src/utils/queue/router/broadcast.ts
@@ -1,7 +1,8 @@
 import { Logger } from '@l2beat/backend-tools'
-import { Queue, Worker } from 'bullmq'
+import { Queue } from 'bullmq'
 import { Redis } from 'ioredis'
 import { InferQueueDataType } from '../types.js'
+import { setupWorker } from '../setup-worker.js'
 
 /**
  * Broadcast events from one queue to multiple queues.
@@ -20,15 +21,15 @@ export function broadcast({
     from: InputQueue
     to: Queue<InputEvent>[]
   }) => {
-    const broadcastWorker = new Worker<InputEvent>(
-      from.name,
-      async (job) => {
+    const broadcastWorker = setupWorker({
+      connection,
+      queue: from,
+      processor: async (job) => {
         to.forEach((queue) => {
           queue.add(job.name, job.data, job.opts)
         })
       },
-      { connection },
-    )
+    })
 
     logger.info('Broadcast rule set', {
       from: from.name,

--- a/src/utils/queue/router/routingKey.ts
+++ b/src/utils/queue/router/routingKey.ts
@@ -5,7 +5,14 @@ import { setupWorker } from '../setup-worker.js'
 import { InferQueueDataType } from '../types.js'
 
 type RoutedQueue<Event, RoutingKey> = {
-  queue: Queue<Event>
+  /**
+   * The queue or queues to route the event to.
+   */
+  queue: Queue<Event> | Queue<Event>[]
+
+  /**
+   * The routing key to use for this queue.
+   */
   routingKey: RoutingKey
 }
 
@@ -32,8 +39,11 @@ export function routingKey({
     to: RoutedQueue<InputEvent, RoutingKey>[]
     extractRoutingKey: (data: InputEvent) => Promise<RoutingKey>
   }) => {
-    const queueMap = new Map<RoutingKey, Queue>(
-      to.map(({ queue, routingKey }) => [routingKey, queue]),
+    const queueMap = new Map<RoutingKey, Queue[]>(
+      to.map(({ queue, routingKey }) => [
+        routingKey,
+        Array.isArray(queue) ? queue : [queue],
+      ]),
     )
 
     if (queueMap.size !== to.length) {
@@ -51,9 +61,11 @@ export function routingKey({
       connection,
       processor: async (job: Job<InputEvent>) => {
         const routingKey = await extractRoutingKey(job.data)
-        const queue = queueMap.get(routingKey)
-        if (queue) {
-          await queue.add(job.name, job.data, job.opts)
+        const queues = queueMap.get(routingKey)
+        if (queues) {
+          await Promise.all(
+            queues.map((queue) => queue.add(job.name, job.data, job.opts)),
+          )
         } else {
           logger
             .tag(from.name)
@@ -63,7 +75,10 @@ export function routingKey({
     })
 
     const mapToLog = Object.fromEntries(
-      Array.from(queueMap.entries()).map(([key, queue]) => [key, queue.name]),
+      Array.from(queueMap.entries()).map(([key, queue]) => [
+        key,
+        queue.map((queue) => queue.name),
+      ]),
     )
 
     logger.info('Routing key rule set', {

--- a/src/utils/queue/setup-worker.ts
+++ b/src/utils/queue/setup-worker.ts
@@ -1,8 +1,15 @@
 import { Logger } from '@l2beat/backend-tools'
-import { Processor, Queue, Worker } from 'bullmq'
+import {
+  Processor,
+  Queue,
+  Worker,
+  WorkerOptions as BullWorkerOptions,
+} from 'bullmq'
 import { Redis } from 'ioredis'
 import { setupWorkerLogging } from './logging.js'
 import { InferQueueDataType, InferQueueResultType } from './types.js'
+
+type WorkerOptions = Pick<BullWorkerOptions, 'concurrency'>
 
 export function setupWorker<
   EventQueue extends Queue,
@@ -13,16 +20,24 @@ export function setupWorker<
   connection,
   processor,
   logger,
+  workerOptions,
 }: {
   queue: EventQueue
   connection: Redis
-  processor: Processor<DataType, ResultType>
+  processor: Processor<DataType>
   logger?: Logger
+  workerOptions?: WorkerOptions
 }) {
-  const worker = new Worker<DataType, ResultType>(queue.name, processor, {
-    connection,
-    concurrency: 1,
-  })
+  const worker = new Worker<DataType, ResultType, string>(
+    queue.name,
+    processor,
+    {
+      connection,
+      concurrency: 1,
+      autorun: false,
+      ...workerOptions,
+    },
+  )
 
   if (logger) {
     setupWorkerLogging({ worker, logger })


### PR DESCRIPTION
Just a sanity clean-up.

Includes:
- Queue modules per source
- Better interface
- Cleaner routing with no one, big file
- Routing key now supports array of queues to route to
- Preserved comments
- Delayed worker execution (we might run one particular module as workers in the future instead of whole app)
- Deployment Processor now propagates events from ethereum to canonical sources since these return nothing if L1 has not been founds, so by wiring up ethereum deployment source output with other canonical chain sources we make sure we do not miss any tokens.
